### PR TITLE
changed project name: override folder name and use custom one

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Get it from https://docs.docker.com/engine/installation/#supported-platforms
 Run your Docker instance and then type the following command on terminal:
 
 ```
-docker-compose up corenlpsrl
+docker-compose --project-name srldocker up corenlpsrl
 ``` 
 
 


### PR DESCRIPTION
The project name comes from the name of the folder, that comes from the name of the github repo by default
One solution is to change the project name (done in this commit)
Or also can use `docker run --network=takefivesrl_srlnet python-barcode` for running the example